### PR TITLE
fix two Non-Idempotent-Outcome flaky tests

### DIFF
--- a/core/src/test/java/com/ccoe/build/core/utils/FileUtilsTest.java
+++ b/core/src/test/java/com/ccoe/build/core/utils/FileUtilsTest.java
@@ -27,6 +27,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.junit.Test;
+
 import com.ccoe.build.core.utils.FileUtils;
 
 public class FileUtilsTest {
@@ -58,8 +59,8 @@ public class FileUtilsTest {
 		File dc = new File(resourceFolder, "diskclean");
 		
 		assertTrue(dc.exists());
-		
-		FileUtils.renameDoneFile(new File(dc, "filestodelete.txt"));    
+
+		FileUtils.renameDoneFile(new File(dc, "filestodelete.txt"));
 		
 		File[] files = FileUtils.loadDoneFiles(dc);
 		assertTrue(files.length > 0);

--- a/core/src/test/java/com/ccoe/build/core/utils/FileUtilsTest.java
+++ b/core/src/test/java/com/ccoe/build/core/utils/FileUtilsTest.java
@@ -93,7 +93,7 @@ public class FileUtilsTest {
 		String unmodified = FileUtils.readFile(file);
 		FileUtils.modifyPropertyFile(file, map);
 		String modified = FileUtils.readFile(file);
-		assertFalse(unmodified.equals(modified));
+		assertFalse(unmodified.equals(modified));		
 		FileUtils.writeToFile(file, unmodified);	
 	}
 }

--- a/core/src/test/java/com/ccoe/build/core/utils/FileUtilsTest.java
+++ b/core/src/test/java/com/ccoe/build/core/utils/FileUtilsTest.java
@@ -27,7 +27,6 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.junit.Test;
-
 import com.ccoe.build.core.utils.FileUtils;
 
 public class FileUtilsTest {
@@ -60,7 +59,7 @@ public class FileUtilsTest {
 		
 		assertTrue(dc.exists());
 		
-		FileUtils.renameDoneFile(new File(dc, "filestodelete.txt"));
+		FileUtils.renameDoneFile(new File(dc, "filestodelete.txt"));    
 		
 		File[] files = FileUtils.loadDoneFiles(dc);
 		assertTrue(files.length > 0);
@@ -77,6 +76,7 @@ public class FileUtilsTest {
 		assertFalse(file.exists());
 		FileUtils.writeToFile(file, "some contents");
 		assertTrue(file.exists());
+		file.delete();
 	}
 	
 	@Test
@@ -92,6 +92,7 @@ public class FileUtilsTest {
 		String unmodified = FileUtils.readFile(file);
 		FileUtils.modifyPropertyFile(file, map);
 		String modified = FileUtils.readFile(file);
-		assertFalse(unmodified.equals(modified));		
+		assertFalse(unmodified.equals(modified));
+		FileUtils.writeToFile(file, unmodified);	
 	}
 }

--- a/core/src/test/java/com/ccoe/build/core/utils/FileUtilsTest.java
+++ b/core/src/test/java/com/ccoe/build/core/utils/FileUtilsTest.java
@@ -59,7 +59,7 @@ public class FileUtilsTest {
 		File dc = new File(resourceFolder, "diskclean");
 		
 		assertTrue(dc.exists());
-
+		
 		FileUtils.renameDoneFile(new File(dc, "filestodelete.txt"));
 		
 		File[] files = FileUtils.loadDoneFiles(dc);


### PR DESCRIPTION
**Description**
Two tests `testWrite()` and `testModifyProperty()` in the file `FileUtilsTest.java` are flaky beacuse they will fail after repeated test runs. Specifically, they create/modify a file but don't delete it or change it back, which pollutes the shared state. It's better to always clean state pollution so that some other tests won’t fail in the future.
One can check the failure with two consecutive `mvn test` commands:
```
mvn  install -pl core -am -DskipTests
mvn -pl core test -Dtest=com.ccoe.build.core.utils.FileUtilsTest
mvn -pl core test -Dtest=com.ccoe.build.core.utils.FileUtilsTest
```
